### PR TITLE
externe und interne links, Beschaffung dient der Sicherstellung der Funktionalität  

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Auch Firmen und Entitäten, die ihre Arbeit nicht ohne weiteres veröffentlichen
 ## Beschaffung
 
 Bei der Beschaffung von Software und Hardware sollen Lösungen aus dem OpenSource Umfeld präferiert werden.
+Um die Funktionalität dieser Software sicherzustellen ist nicht nur OpenSource Software zu benutzen, sondern dazu auch Dienstleistungen zu beschaffen.
 Dies schließt zahlreiche [Geschäftsmodelle für Open-Source-Software](https://de.wikipedia.org/wiki/Gesch%C3%A4ftsmodelle_f%C3%BCr_Open-Source-Software#Ans%C3%A4tze) mit ein:
 
 * es werden __Supportverträge__ für genutzte OpenSource Software beschafft (z.B. RedHat RHEL)

--- a/README.md
+++ b/README.md
@@ -26,16 +26,18 @@ Durch offenen Quellcode, offene Standards und offene Schnittstellen ermöglichen
 
 ### Public Money, Public Code
 
-Software, die von der öffentlichen Verwaltung entwickelt wird, ist bereits durch Steuergelder finanziert. Sie sollte damit als Allgemeingut den Bürger\*innen zur Verfügung stehen, wenn es dafür Verwendung gibt. Auch andere Kommunen oder Behörden können Open Source Software wiederverwenden und damit eigene Entwicklungskosten oder Lizenzgebühren für proprietäre Anbieter einsparen. 
+[Von allen bezahlter Code sollte für alle verfügbar sein!](https://publiccode.eu/de/). Software, die von der öffentlichen Verwaltung entwickelt wird, ist bereits durch Steuergelder finanziert. Sie sollte damit als Allgemeingut den Bürger\*innen zur Verfügung stehen, wenn es dafür Verwendung gibt. Auch andere Kommunen oder Behörden können Open Source Software wiederverwenden und damit eigene Entwicklungskosten oder Lizenzgebühren für proprietäre Anbieter einsparen.
 
 ## Offene Standards als Basis
 Die Softwareprodukte, die in der Landeshauptstadt München verwendet werden, sind miteinander vernetzt. Zudem werden zwischen der LHM und anderen Behörden Daten ausgetauscht. Deshalb ist es wichtig, neben FOSS auch auf offene Standards zu setzen. 
+
+[Ein Offener Standard ist ein Format oder Protokoll](https://fsfe.org/freesoftware/standards/def.de.html) das nur von anderen offenen Formaten abhängt, frei von rechtlichen Klauseln oder technischen Einschränkungen ist, gleichberechtigten weiterentwickelt wird, gleichermaßen für alle Beteiligten verfügbar ist und öffentlich geprüft und verwendet werden kann.
 
 ### Dokumentenstandards
 In einer Behörde sind sehr viele Prozesse an Dokumenten orientiert. Deshalb sollen offene und damit von allen verwendbare Dokumentformate verwendet werden. Dies sind in der Regel Formate, deren Spezifikation von offenen Standardisierungsorganisationen betreut werden (z.B. PDF von der PDF Association), oder die entsprechend normiert sind (beispielsweise das Open Document Format nach ISO/IEC 26300).
 
 ### Austauschformate
-Die Landeshauptstadt München tauscht regelmäßig Daten mit anderen Behörden aus. Hier ist es wichtig, dass diese Daten medienbruchfrei und automatisiert verarbeitet werden können. Für behördliche Spezialthemen (z.B. Einwohnermeldewesen oder Ausländerwesen) gibt es hier standardisierte Austauschformate wie XÖV (https://www.xoev.de/). Die Nutzung der XÖV-Formate ist häufig vom Gesetzgeber vorgeschrieben (z.B. im Bundesmeldegesetz). Darüber hinaus sollen auch in anderen Bereichen offene Austauschformate verwendet werden, wenn solche vorhanden sind.
+Die Landeshauptstadt München tauscht regelmäßig Daten mit anderen Behörden aus. Hier ist es wichtig, dass diese Daten medienbruchfrei und automatisiert verarbeitet werden können. Für behördliche Spezialthemen (z.B. Einwohnermeldewesen oder Ausländerwesen) gibt es hier standardisierte Austauschformate wie [XÖV](https://www.xoev.de). Die Nutzung der XÖV-Formate ist häufig vom Gesetzgeber vorgeschrieben (z.B. im Bundesmeldegesetz). Darüber hinaus sollen auch in anderen Bereichen offene Austauschformate verwendet werden, wenn solche vorhanden sind.
 
 ### Standardisierte Protokolle
 Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleisten, sollen die verwendeten Software Produkte ihre Schnittstellen über standardisierte und offene Protokolle zur Verfügung stellen. Solche Protokolle werden in der Regel von einer Standardisierungsorganisation (z.B. HTTP vom World Wide Web Consortium W3C) normiert und sind in der IT-Community weit verbreitet.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Es definiert Voraussetzungen, Abhängigkeiten, Ausschlüsse und Zielrichtung von
 Die Entscheidung für Open Source kann aus unterschiedlichen Gründen und Zugängen erfolgen, diese haben jeweils unterschiedliche Konsequenzen für die Umsetzung:
 
 ### Rückgewinnung digitaler Souveränität
-Durch offenen Quellcode, offene Standards und offene Schnittstellen ermöglichen wir eine Zusammenarbeit über eine Organisation hinaus. Dadurch lassen sich Gegengewichte zu den Netzwerkeffekten der großen Softwarekonzerne entwickeln. Offene Standards und Schnittstellen reduzieren zusätzlich die Herstellerabhängigkeit und ermöglichen größere Diversität.
+Durch offenen Quellcode, [offene Standards](#offene-standards) und offene Schnittstellen ermöglichen wir eine Zusammenarbeit über eine Organisation hinaus. Dadurch lassen sich Gegengewichte zu den Netzwerkeffekten der großen Softwarekonzerne entwickeln. Offene Standards und Schnittstellen reduzieren zusätzlich die Herstellerabhängigkeit und ermöglichen größere Diversität.
 
 ### Sicherheit
 
@@ -48,7 +48,7 @@ Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleis
 
 ## Individualentwicklungen
 
-Individualentwicklungen sollen grundsätzlich mit Open-Source-Frameworks und basierend auf Open-Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer Open-Source-Lizenz zur Verfügung zu stellen. 
+Individualentwicklungen sollen grundsätzlich mit Open-Source-Frameworks und basierend auf Open-Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer [Open-Source-Lizenz](#lizenzen) zur Verfügung zu stellen.
 
 ## Lizenzen
 
@@ -66,7 +66,7 @@ Bei "freizügigen" Lizenzen (wie der [MIT](https://choosealicense.com/licenses/m
 Auch Firmen und Entitäten, die ihre Arbeit nicht ohne weiteres veröffentlichen können, können solche Software ohne Bedenken nutzen und für ihre Zwecke anpassen.
 
   - Die Stadt München soll Open Source Software unabhängig von diesen Kategorien nutzen können. Copyleft- wie auch freizügige Lizenzen sind besser als proprietäre Nutzungsverträge.
-  - Stellt die Stadt München selbst Software her, sollte sie eine freizügige Lizenz (wie MIT) wählen.
+  - Stellt die Stadt München [selbst Software her](#individualentwicklungen), sollte sie eine freizügige Lizenz (wie MIT) wählen.
 
 ## Beschaffung
 
@@ -75,7 +75,7 @@ Dies schließt zahlreiche [Geschäftsmodelle für Open-Source-Software](https://
 
 * es werden __Supportverträge__ für genutzte OpenSource Software beschafft (z.B. RedHat RHEL)
 * es werden __Beratungsleistungen__ zur Einführung, Betrieb und Weiterentwicklung von OpenSource Software beschafft.
-* es werden auch __Lizenzen__ für dual-lizenzierte __proprietäre Erweiterungen__ von Software beschafft, deren freie Versionen bereits im Einsatz sind und deren relevanter Teil quelloffen ist (z.B. GitLab).
+* es werden auch __Lizenzen__ für [dual-lizenzierte](#lizenzen) __proprietäre Erweiterungen__ von Software beschafft, deren freie Versionen bereits im Einsatz sind und deren relevanter Teil quelloffen ist (z.B. GitLab).
 
-Die Landeshauptstadt München beschafft so professionelle Softwarelösungen, ohne sich mit der benutzten Software in eine Herstellerabhängigkeit zu begeben.
+Die Landeshauptstadt München beschafft so professionelle Softwarelösungen, ohne sich mit der benutzten Software in eine [Herstellerabhängigkeit](#keine-herstellerabhängigkeiten) zu begeben.
 So können Leistungen jederzeit neu ausgeschrieben und bestmöglich am Markt vergeben werden.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Durch offenen Quellcode, offene Standards und offene Schnittstellen ermöglichen
 
 [Von allen bezahlter Code sollte für alle verfügbar sein!](https://publiccode.eu/de/). Software, die von der öffentlichen Verwaltung entwickelt wird, ist bereits durch Steuergelder finanziert. Sie sollte damit als Allgemeingut den Bürger\*innen zur Verfügung stehen, wenn es dafür Verwendung gibt. Auch andere Kommunen oder Behörden können Open Source Software wiederverwenden und damit eigene Entwicklungskosten oder Lizenzgebühren für proprietäre Anbieter einsparen.
 
-## Offene Standards als Basis
+## Offene Standards
 Die Softwareprodukte, die in der Landeshauptstadt München verwendet werden, sind miteinander vernetzt. Zudem werden zwischen der LHM und anderen Behörden Daten ausgetauscht. Deshalb ist es wichtig, neben FOSS auch auf offene Standards zu setzen. 
 
 [Ein Offener Standard ist ein Format oder Protokoll](https://fsfe.org/freesoftware/standards/def.de.html) das nur von anderen offenen Formaten abhängt, frei von rechtlichen Klauseln oder technischen Einschränkungen ist, gleichberechtigten weiterentwickelt wird, gleichermaßen für alle Beteiligten verfügbar ist und öffentlich geprüft und verwendet werden kann.

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ Dies schließt zahlreiche [Geschäftsmodelle für Open-Source-Software](https://
 * es werden __Beratungsleistungen__ zur Einführung, Betrieb und Weiterentwicklung von OpenSource Software beschafft.
 * es werden auch __Lizenzen__ für dual-lizenzierte __proprietäre Erweiterungen__ von Software beschafft, deren freie Versionen bereits im Einsatz sind und deren relevanter Teil quelloffen ist (z.B. GitLab).
 
-Die Landeshauptstadt München beschafft so professionelle Softwarelösungen, ohne sich mit der benutzten Software in eine Herstellerabhängekeit zu begeben.
+Die Landeshauptstadt München beschafft so professionelle Softwarelösungen, ohne sich mit der benutzten Software in eine Herstellerabhängigkeit zu begeben.
 So können Leistungen jederzeit neu ausgeschrieben und bestmöglich am Markt vergeben werden.


### PR DESCRIPTION
Ich habe

* externe und interne links hinzugefügt
* inhaltlich einen Satz: Beschaffung dient der Sicherstellung der Funktionalität  
* ein typo
* eine Überschrift gekürzt  