### PR TITLE
Eigenentwicklungen aus Antragstext erweitert

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleis
 ## Individualentwicklungen
 
 Individualentwicklungen sollen grundsätzlich mit Open Source-Frameworks und basierend auf Open Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer [Open Source-Lizenz](#lizenzen) zur Verfügung zu stellen.
-
-Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Leistungsfähigkeit und Benutzer*innenfreundlichkeit der entwickelten Software im Produktiveinsatz gewährleistet sind, sowie die technische und finanzielle Machbarkeit.
 
 Der entwickelte Quellcode wird öffentlich zugänglich gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
@@ -65,6 +63,7 @@ Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity 
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
 Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
 
+Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 
 ## Betrieb von Open Source-Software
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,39 @@ Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleis
 
 Individualentwicklungen sollen grundsätzlich mit Open Source-Frameworks und basierend auf Open Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer [Open Source-Lizenz](#lizenzen) zur Verfügung zu stellen.
 
+Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
+Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Leistungsfähigkeit und Benutzer*innenfreundlichkeit der entwickelten Software im Produktiveinsatz gewährleistet sind, sowie die technische und finanzielle Machbarkeit.
+Wird ein Projekt als ungeeignet für die Open Source-Entwicklung eingestuft, muss diese Entscheidung dem IT-Ausschuss bekannt gegeben und fachlich begründet werden.
+In der ersten Stufe schlägt das IT-Referat dem Stadtrat fünf Projekte auf dem Hoheitsgebiet der Landeshauptstadt München vor, die kurzfristig als Open Source Projekt realisiert werden.
+
+In der zweiten Stufe wird ab dem 4. Quartal 2021 auf dem Hoheitsgebiet neue Individualsoftware grundsätzlich auf der Basis von Open Source entwickelt.
+Der entwickelte Quellcode wird öffentlich zugänglich gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
+Um externe Beiträge zu ermöglichen, sind Contribution Rules zu formulieren.
+Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und auch kein Support geleistet werden kann, sowie das Ende eines Projektes zu berücksichtigen, also auch die Möglichkeit, dass die Landeshauptstadt veröffentlichten Code ggf. nicht weiter pflegt.
+
+Die Sprache des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
+Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
+Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
+Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen Repository wie zum Beispiel https://github.com/it-at-mstatt, zusätzlich auf einem internen Mirror wie https://git.muenchen.de.
+Zusätzlich werden die Repositories der Open Source Business Alliance gemirrored.
+Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
+Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
+Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
+
+Das IT-Referat führt Schulungen für Software-Entwickler*innen in der Entwicklung von Open Source-Software je nach Anwendungsbereich auf Windows, Linux oder anderen Betriebssystemen und Plattformen durch.
+
+Eigene Software-Entwicklungen (Fall „Make“ bei MBUC-Analyse) auf dem Hoheitsgebiet der Landeshauptstadt München sollen grundsätzlich im Open Source-Kontext stattfinden.
+Unter neue Individualsoftware fällt Open Office/LibreOffice explizit nicht.
+Vom Open Source-Prinzip kann in begründeten Fällen abgewichen werden.
+Diese Entscheidungen sind fachlich auszuführen und im IT-Ausschuss bekannt zu geben.
+Bereits heute gibt es im Eigenbetrieb it@M Open Source-begeisterte Expert*innen, deren Kriterien für qualitativ hochwertigen Quellcode Beachtung finden sollten.
+Dazu gehören insbesondere die Auswahl geeigneter Open Source-Lizenzen, die verwendeten Plattformen und ein Kodex für sauberen Quellcode.
+Die Open Source-Community soll ermutigt werden, an den Software-Projekten der Landeshauptstadt München mitzuwirken.
+Das geschieht aber in der Regel nur bei hochwertigen und gut gepflegten Software-Projekten.
+Das Veröffentlichen von Software führt in der Regel bereits zu qualitativ hochwertigem Quellcode.
+Um schnelle und provisorische Lösungen zu vermeiden und die internen Gesamtkosten zu reduzieren, sind Mehraufwände durch „Clean Code“ jedoch grundsätzlich im Projekt zu tragen.
+
+
 ## Betrieb von Open Source-Software
 
 Open Source-Software mit anderen Behörden oder Kommunen zu teilen bedeutet, dass jede\*r die Software selber betreiben muss. Da insbesondere kleinere Kommunen nicht das Knowhow haben, Software selber zu betreiben, soll die Stadt München 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Lei
 * Der entwickelte Quellcode wird __öffentlich zugänglich__ gemacht und unter eine freizügige [Open Source-Lizenz](#lizenzen) (z.B. EUPL, MIT) gestellt.
 Um externe Beiträge zu ermöglichen, sind Contribution Rules zu formulieren.
 Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und auch kein Support geleistet werden kann, sowie das Ende eines Projektes zu berücksichtigen, also auch die Möglichkeit, dass die Landeshauptstadt veröffentlichten Code ggf. nicht weiter pflegt.
-* Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
-Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
-Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
 * Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen __Repository__ wie zum Beispiel [github.com/it-at-m](https://github.com/it-at-m) statt, zusätzlich auf einem internen Mirror wie git.muenchen.de.
 Zusätzlich werden die Repositories der [Open Source Business Alliance](https://osb-alliance.de/) gemirrored.
 * Es werden offene, austauschbare [Schnittstellen](#standardisierte-protokolle) verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
+* Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
+Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
+Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
 * Mehraufwände durch [Clean Code](https://de.wikipedia.org/wiki/Clean_Code), also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und au
 * Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen __Repository__ wie zum Beispiel [github.com/it-at-m](https://github.com/it-at-m) statt, zusätzlich auf einem internen Mirror wie git.muenchen.de.
 Zusätzlich werden die Repositories der [Open Source Business Alliance](https://osb-alliance.de/) gemirrored.
 * Es werden offene, austauschbare [Schnittstellen](#standardisierte-protokolle) verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
-Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
+Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF ([European Interoperability Framework](https://ec.europa.eu/isa2/eif_en)) angewandt werden.
 * Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
 Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
 Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.

--- a/README.md
+++ b/README.md
@@ -50,18 +50,17 @@ Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleis
 Individualentwicklungen sollen grundsätzlich mit Open Source-Frameworks und basierend auf Open Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer [Open Source-Lizenz](#lizenzen) zur Verfügung zu stellen.
 Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Leistungsfähigkeit und Benutzer*innenfreundlichkeit der entwickelten Software im Produktiveinsatz gewährleistet sind, sowie die technische und finanzielle Machbarkeit.
 
-Der entwickelte Quellcode wird öffentlich zugänglich gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
+* Der entwickelte Quellcode wird __öffentlich zugänglich__ gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
 Um externe Beiträge zu ermöglichen, sind Contribution Rules zu formulieren.
 Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und auch kein Support geleistet werden kann, sowie das Ende eines Projektes zu berücksichtigen, also auch die Möglichkeit, dass die Landeshauptstadt veröffentlichten Code ggf. nicht weiter pflegt.
-
-Die Sprache des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
+* Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
 Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
 Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
-Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen Repository wie zum Beispiel https://github.com/it-at-mstatt, zusätzlich auf einem internen Mirror wie https://git.muenchen.de.
+* Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen __Repository__ wie zum Beispiel [github.com/it-at-m](https://github.com/it-at-m) statt, zusätzlich auf einem internen Mirror wie git.muenchen.de.
 Zusätzlich werden die Repositories der Open Source Business Alliance gemirrored.
-Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
+* Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
-Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
+* Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und au
 Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
 Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
 * Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen __Repository__ wie zum Beispiel [github.com/it-at-m](https://github.com/it-at-m) statt, zusätzlich auf einem internen Mirror wie git.muenchen.de.
-Zusätzlich werden die Repositories der Open Source Business Alliance gemirrored.
+Zusätzlich werden die Repositories der [Open Source Business Alliance](https://osb-alliance.de/) gemirrored.
 * Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
-* Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
+* Mehraufwände durch [Clean Code](https://de.wikipedia.org/wiki/Clean_Code), also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,7 @@ Individualentwicklungen sollen grundsätzlich mit Open Source-Frameworks und bas
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Leistungsfähigkeit und Benutzer*innenfreundlichkeit der entwickelten Software im Produktiveinsatz gewährleistet sind, sowie die technische und finanzielle Machbarkeit.
-Wird ein Projekt als ungeeignet für die Open Source-Entwicklung eingestuft, muss diese Entscheidung dem IT-Ausschuss bekannt gegeben und fachlich begründet werden.
-In der ersten Stufe schlägt das IT-Referat dem Stadtrat fünf Projekte auf dem Hoheitsgebiet der Landeshauptstadt München vor, die kurzfristig als Open Source Projekt realisiert werden.
 
-In der zweiten Stufe wird ab dem 4. Quartal 2021 auf dem Hoheitsgebiet neue Individualsoftware grundsätzlich auf der Basis von Open Source entwickelt.
 Der entwickelte Quellcode wird öffentlich zugänglich gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
 Um externe Beiträge zu ermöglichen, sind Contribution Rules zu formulieren.
 Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und auch kein Support geleistet werden kann, sowie das Ende eines Projektes zu berücksichtigen, also auch die Möglichkeit, dass die Landeshauptstadt veröffentlichten Code ggf. nicht weiter pflegt.
@@ -67,19 +64,6 @@ Zusätzlich werden die Repositories der Open Source Business Alliance gemirrored
 Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
 Mehraufwände durch „Clean Code“, also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
-
-Das IT-Referat führt Schulungen für Software-Entwickler*innen in der Entwicklung von Open Source-Software je nach Anwendungsbereich auf Windows, Linux oder anderen Betriebssystemen und Plattformen durch.
-
-Eigene Software-Entwicklungen (Fall „Make“ bei MBUC-Analyse) auf dem Hoheitsgebiet der Landeshauptstadt München sollen grundsätzlich im Open Source-Kontext stattfinden.
-Unter neue Individualsoftware fällt Open Office/LibreOffice explizit nicht.
-Vom Open Source-Prinzip kann in begründeten Fällen abgewichen werden.
-Diese Entscheidungen sind fachlich auszuführen und im IT-Ausschuss bekannt zu geben.
-Bereits heute gibt es im Eigenbetrieb it@M Open Source-begeisterte Expert*innen, deren Kriterien für qualitativ hochwertigen Quellcode Beachtung finden sollten.
-Dazu gehören insbesondere die Auswahl geeigneter Open Source-Lizenzen, die verwendeten Plattformen und ein Kodex für sauberen Quellcode.
-Die Open Source-Community soll ermutigt werden, an den Software-Projekten der Landeshauptstadt München mitzuwirken.
-Das geschieht aber in der Regel nur bei hochwertigen und gut gepflegten Software-Projekten.
-Das Veröffentlichen von Software führt in der Regel bereits zu qualitativ hochwertigem Quellcode.
-Um schnelle und provisorische Lösungen zu vermeiden und die internen Gesamtkosten zu reduzieren, sind Mehraufwände durch „Clean Code“ jedoch grundsätzlich im Projekt zu tragen.
 
 
 ## Betrieb von Open Source-Software

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Um eine optimale Kommunikation innerhalb der Anwendungslandschaft zu gewährleis
 Individualentwicklungen sollen grundsätzlich mit Open Source-Frameworks und basierend auf Open Source-Komponenten entwickelt werden, unabhängig davon, ob die Software von der Stadt München oder einem Dienstleister im Auftrag entwickelt wird. Das ist Voraussetzung, um diese Fachanwendungen anderen Organisationen unter einer [Open Source-Lizenz](#lizenzen) zur Verfügung zu stellen.
 Notwendige Kriterien für die Auswahl als Open Source-Projekt sind, dass die Leistungsfähigkeit und Benutzer*innenfreundlichkeit der entwickelten Software im Produktiveinsatz gewährleistet sind, sowie die technische und finanzielle Machbarkeit.
 
-* Der entwickelte Quellcode wird __öffentlich zugänglich__ gemacht und unter eine freizügige Open Source-Lizenz (z.B. EUPL, MIT) gestellt.
+* Der entwickelte Quellcode wird __öffentlich zugänglich__ gemacht und unter eine freizügige [Open Source-Lizenz](#lizenzen) (z.B. EUPL, MIT) gestellt.
 Um externe Beiträge zu ermöglichen, sind Contribution Rules zu formulieren.
 Hierbei sind auch Hinweise zu machen, dass keine Haftung übernommen wird und auch kein Support geleistet werden kann, sowie das Ende eines Projektes zu berücksichtigen, also auch die Möglichkeit, dass die Landeshauptstadt veröffentlichten Code ggf. nicht weiter pflegt.
 * Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
@@ -58,7 +58,7 @@ Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
 Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
 * Die Entwicklung findet von Anfang an auf einem geeigneten öffentlichen __Repository__ wie zum Beispiel [github.com/it-at-m](https://github.com/it-at-m) statt, zusätzlich auf einem internen Mirror wie git.muenchen.de.
 Zusätzlich werden die Repositories der [Open Source Business Alliance](https://osb-alliance.de/) gemirrored.
-* Es werden offene, austauschbare Schnittstellen verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
+* Es werden offene, austauschbare [Schnittstellen](#standardisierte-protokolle) verwendet: Datenbanken, Identity Provider etc. müssen im Quellcode austauschbar sein.
 Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten EIRA Standards des EIF (European Interoperability Framework) angewandt werden.
 * Mehraufwände durch [Clean Code](https://de.wikipedia.org/wiki/Clean_Code), also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Dabei sollten insbesondere die von der Europäischen Kommission 2017 definierten
 * Die __Sprache__ des Quellcodes ist Englisch bis auf landesspezifische Fachsprache.
 Die Dokumentation kann auf Englisch oder Deutsch erfolgen.
 Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
-* Mehraufwände durch [Clean Code](https://de.wikipedia.org/wiki/Clean_Code), also das Befolgen eines Kodex für sauberen Quellcode, sind grundsätzlich im Projekt zu tragen.
+* Durch den Einsatz von [Clean Code](https://de.wikipedia.org/wiki/Clean_Code), also das Befolgen eines Kodex für sauberen Quellcode, wird Wartbarkeit, Erweiterbarkeit, Wiederverwendbarkeit und eine höhere [Sicherheit](#sicherheit) ermöglicht.
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 FOSS-Konzept Grün-Rot München 2020
 ==================================
 
-<!---
-Hier entsteht das Free and Open Source-Software-Konzept der grün-roten Regierungskoalition im Münchner Rathaus.
-Wir freuen uns über Eure Teilnahme und Euer Feedback!
--->
-
 Die [Koalitionsvereinbarung für die Stadtratsperiode 2020 –2026 zwischen Oberbürgermeister Dieter Reiter, den Münchner Parteien SPD und Die Grünen, der Stadtratsfraktion Die Grünen–Rosa Liste und der Fraktionsgemeinschaft SPD/Volt](https://www.gruene-muenchen.de/wp-content/uploads/2020/04/Druckfassung_Koalitionsvertrag-2020_2026.pdf) nennt unter dem Abschnitt "XII.Digitalisierung als Chance" folgende Punkte:
 
 > Wo immer technisch und finanziell möglich setzt die Stadt auf offene Standards und freie Open Source-lizenzierte Software und vermeidet damit absehbare Herstellerabhängigkeiten. Diese Abwägung nehmen wir als Kriterium für Ausschreibungen mit auf, eine Abweichung von diesem Grundsatz muss begründet werden. Die Stadt unterhält ein öffentlich zugängliches Open Source Dashboard inkl. Kostenbilanz (auch bei Betriebssystemen und Office-Anwendungen), aus dem hervorgeht, in welchen Bereichen die Landeshauptstadt München auf Open Source setzt und welche Fortschritte in diesem Bereich gemacht wurden.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Das Benutzerhandbuch muss mindestens auf Deutsch verfügbar sein.
 
 Das IT-Referat, vertreten durch seine Software-Architekt*innen, entscheidet über die Open Source-Eignung eines Projektes nach der MBUC-Analyse („Make-Buy-Use-Compose“).
 
+Dazu ist der Antrag [Neue Software im Open Source-Kontext entwickeln!](https://www.muenchen-transparent.de/antraege/6289779) _In Bearbeitung_.
+
+
 ## Betrieb von Open Source-Software
 
 Open Source-Software mit anderen Behörden oder Kommunen zu teilen bedeutet, dass jede\*r die Software selber betreiben muss. Da insbesondere kleinere Kommunen nicht das Knowhow haben, Software selber zu betreiben, soll die Stadt München 

--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -1,0 +1,4 @@
+# Contribution guidelines
+
+Hier entsteht das Free and Open Source-Software-Konzept der grün-roten Regierungskoalition im Münchner Rathaus.
+Wir freuen uns über Eure Teilnahme und Euer Feedback!

--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -4,4 +4,4 @@ Hier entsteht das Free and Open Source-Software-Konzept der grün-roten Regierun
 Wir freuen uns über Eure Teilnahme und Euer Feedback!
 
 * In einem Absatz, jeden Satz als neue Zeile anlegen.
-So bleibt bei Änderungen an anderen Sätze des Absatz die [Urheberschaft](https://github.com/missgreenwood/foss-concept/graphs/contributors) erhalten.
+So bleibt bei Änderungen an anderen Sätzen des Absatzes die [Urheberschaft](https://github.com/missgreenwood/foss-concept/graphs/contributors) erhalten.

--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -2,3 +2,6 @@
 
 Hier entsteht das Free and Open Source-Software-Konzept der grün-roten Regierungskoalition im Münchner Rathaus.
 Wir freuen uns über Eure Teilnahme und Euer Feedback!
+
+* In einem Absatz, jeden Satz als neue Zeile anlegen.
+So bleibt bei Änderungen an anderen Sätze des Absatz die [Urheberschaft](https://github.com/missgreenwood/foss-concept/graphs/contributors) erhalten.


### PR DESCRIPTION
Eigenentwicklungen aus Antrag [Neue Software im Open Source-Kontext entwickeln!](https://www.muenchen-transparent.de/antraege/6289779) erweitert.

* Begründung und zeitlichen Stufenplan raus genommen
* liste
* links (intern extern)
* Clean Code begründet